### PR TITLE
Issue 33: no timely returned WL_CONNECTED status

### DIFF
--- a/examples/simplesample_http/simplesample_http.ino
+++ b/examples/simplesample_http/simplesample_http.ino
@@ -97,9 +97,13 @@ void initWifi() {
 
     // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
     while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
+        delay(5000);
+        //check after an initial time if the status is now connected, if not retry.
+        if(WiFi.status() == WL_CONNECTED) {
+            break;
+        }
         // unsuccessful, retry in 4 seconds
         Serial.print("failed ... ");
-        delay(4000);
         Serial.print("retrying ... ");
     }
 


### PR DESCRIPTION
The ESP libs for Wifi take a bit longer to initiate and return a WL_CONNECTED. Added a longer delay before checking if WL_CONNECTED and breaking the while loop.

This will solve [ISSUE  #33](https://github.com/Azure/azure-iot-arduino/issues/33).