### PR TITLE
Fix broken Sparkfun/Huzzah "Get Started" links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ You should have the following ready before beginning with any board:
 
 7. Run the sample.
 	
-8. Access the [SparkFun Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-thingdev-getstartedkit/) tutorial to learn more about Microsoft Sparkfun Dev Kit.
+8. Access the [SparkFun Get Started](https://github.com/Azure-Samples/iot-hub-c-thingdev-getstartedkit) tutorial to learn more about Microsoft Sparkfun Dev Kit.
 
-9. Access the [Huzzah Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-huzzah-getstartedkit/) tutorial to learn more about Microsoft Huzzah Dev Kit.
+9. Access the [Huzzah Get Started](https://github.com/Azure-Samples/iot-hub-c-huzzah-getstartedkit) tutorial to learn more about Microsoft Huzzah Dev Kit.
 
 ## ESP32
 


### PR DESCRIPTION
It appears the Sparkfun and Huzzah "Get Started" links are 404'd, perhaps because these samples are obsolete. To start the conversation let's link to the archived Github repositories instead, which should explain why they're obsolete ideally. (Perhaps it'd be more appropriate to just remove points 8 and 9 here, remove the links entirely.)